### PR TITLE
Respect umask when chmodding the path

### DIFF
--- a/src/PhiveHandler.php
+++ b/src/PhiveHandler.php
@@ -95,7 +95,7 @@ class PhiveHandler
 		fclose($fi);
 		fclose($fo);
 
-		chmod($this->path, 0755);
+		chmod($this->path, 0777 & ~umask());
 	}
 
 }


### PR DESCRIPTION
In my environment I have an restrictive umask so files are not created with read access for `other`.
`chmod` will not respect the environments umask.

See: https://developers.shopware.com/blog/2016/02/26/file-permissions-and-umask-in-php-and-shopware/#umask-in-php

